### PR TITLE
Feature/Generate Menu page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "projectskeletontest",
       "version": "0.0.0",
       "dependencies": {
+        "moment": "^2.30.1",
         "react": "^18.3.1",
+        "react-day-picker": "^9.5.0",
         "react-dom": "^18.3.1",
+        "react-moment": "^1.1.3",
         "react-router-dom": "^6.26.2-pre.0",
         "react-select": "^5.9.0"
       },
@@ -338,6 +341,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -2317,6 +2326,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -4131,6 +4156,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4747,6 +4781,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.5.0.tgz",
+      "integrity": "sha512-WmJnPFVLnKh5Qscm7wavMNg86rqPverSWjx+zgK8/ZmGRSQ8c8OoqW10RI+AzAfT2atIxImpCUU2R9Z7Xb2SUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4765,6 +4820,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-moment": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-moment/-/react-moment-1.1.3.tgz",
+      "integrity": "sha512-8EPvlUL8u6EknPp1ISF5MQ3wx2OHJVXIP/iZc4wRh3iV3XozftZERDv9ANZeAtMlhNNQHdFoqcZHFUkBSTONfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "moment": "^2.29.0",
+        "prop-types": "^15.7.0",
+        "react": "^16.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "moment": "^2.30.1",
     "react": "^18.3.1",
+    "react-day-picker": "^9.5.0",
     "react-dom": "^18.3.1",
+    "react-moment": "^1.1.3",
     "react-router-dom": "^6.26.2-pre.0",
     "react-select": "^5.9.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import RootLayout from "./pages/Root.jsx";
 import Home from "./pages/Home.jsx";
 import Allergies from "./pages/Allergies.jsx";
 import dataDishesLoader from "./data/dishes.js";
+import GenerateMenu from "./pages/GenerateMenu.jsx";
 
 export const AppContext = createContext([]);
 
@@ -23,6 +24,10 @@ function App() {
                     path: "Allergies",
                     loader: dataDishesLoader,
                     element: <Allergies />,
+                },
+                {
+                    path: "GenerateMenu",
+                    element: <GenerateMenu />,
                 },
             ],
         },

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import moment from "moment";
+import {DayPicker} from "react-day-picker";
+import getWeekDays from "../functions/getWeekDays.js";
+
+
+//returns an object with the start and end of a week by looking at the date selected
+function getWeekRange(date) {
+  return {
+    from: moment(date).startOf("isoWeek").toDate(),
+    to: moment(date).endOf("isoWeek").toDate(),
+  };
+}
+
+export default function Calendar({onSelectedDaysChange}) {
+  const [hoverRange, setHoverRange] = useState(undefined);
+  const [selectedDays, setSelectedDays] = useState([]);
+
+  //takes in selected date to obtain array from getWeekDays to be raised to GenerateMenu
+  const handleDayChange = (date) => {
+    setSelectedDays(getWeekDays(getWeekRange(date).from));
+    onSelectedDaysChange(getWeekDays(getWeekRange(date).from))
+    console.log(getWeekDays(getWeekRange(date).from))
+  };
+
+  const handleDayEnter = (date) => {
+    setHoverRange(getWeekRange(date));
+  };
+
+  const handleDayLeave = () => {
+    setHoverRange(undefined);
+  };
+
+
+  const daysAreSelected = selectedDays.length > 0;
+
+  //TO-DO understand this
+  const modifiers = {
+    hoverRange,
+    selectedRange: daysAreSelected && {
+      from: selectedDays[0],
+      to: selectedDays[6],
+    },
+    hoverRangeStart: hoverRange && hoverRange.from,
+    hoverRangeEnd: hoverRange && hoverRange.to,
+    selectedRangeStart: daysAreSelected && selectedDays[0],
+    selectedRangeEnd: daysAreSelected && selectedDays[6],
+  };
+
+  return (
+    <div className="w-1/3 space-y-4 p-4 bg-gray-100 rounded-lg shadow">
+      <DayPicker
+        weekStartsOn={1}
+        //disabled={{ before: new Date() }}
+        selectedDays={selectedDays}
+        showOutsideDays={false}
+        modifiers={modifiers}
+        onDayClick={handleDayChange}
+        onDayMouseEnter={handleDayEnter}
+        onDayMouseLeave={handleDayLeave}
+        className=" w-full border border-gray-300 rounded-lg bg-white flex flex-row justify-center"
+      />
+      {selectedDays.length === 7 && (
+        <div className="text-center text-lg font-medium text-gray-800">
+          {moment(selectedDays[0]).format("LL")} –{" "}
+          {moment(selectedDays[6]).format("LL")}
+        </div>
+      )}
+      
+    </div>
+  );
+}

--- a/src/functions/getWeekDays.js
+++ b/src/functions/getWeekDays.js
@@ -1,0 +1,13 @@
+import moment from "moment";
+//takes in the starting day of the week and returns an array of the days of that week (Mon-Sun)
+export default function getWeekDays(weekStart) {
+      const days = [];
+    
+      for (let i = 0; i < 7; i += 1) {
+        //changes DATE data into an ISO date format STRING and keeps only yyyy-mm-dd (ex: "2025-01-23")
+        days.push(moment(weekStart).add(i, "days").toDate().toISOString().slice(0, 10));
+      }
+
+      return days;
+    
+}

--- a/src/pages/GenerateMenu.jsx
+++ b/src/pages/GenerateMenu.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Calendar from '../components/Calendar.jsx'
+import {useState} from 'react'
+
+export default function GenerateMenu() {
+
+    const [selectedDaysFromCalendar, setSelectedDaysFromCalendar] = useState([])
+
+    const handleSelectedDaysUpdate = (days) => {
+        setSelectedDaysFromCalendar(days)
+    }
+  return (
+    <div className="w-screen">
+        <h2 className="text-center m-4">Generate Menu</h2>
+        <div className="flex flex-col w-full">
+            <div className="flex flex-col items-center w-full">
+                <h2 className="text-center items-center m-3">Select Date</h2>
+                <span className="text-center items-center m-2">Choose a week to generate a menu for</span>
+                <Calendar onSelectedDaysChange={handleSelectedDaysUpdate}/>
+            </div>
+            <div>
+
+            </div>
+        <button onClick={() => console.log(selectedDaysFromCalendar)}>test</button>
+
+        </div>
+    </div>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,13 @@
 import { WeeklyMenu } from "../components/weekly-menu/WeeklyMenu";
+import { NavLink } from "react-router-dom";
+
 
 export default function Home() {
     return (
-        <>
-            <button className="flex items-center ml-auto bg-slate-300 hover:bg-slate-200 text-black my-5 py-2 px-6 rounded-full">
-                <span className="mr-3">+</span> Generate Menu
-            </button>
+        <div className="flex flex-col items-center">
+            <div className="flex flex-row w-full justify-end">
+                <NavLink className="bg-blue-400 rounded-3xl p-3 m-3 w-1/6 text-center  hover:bg-gray-200" to={"/GenerateMenu"}>+ Generate Menu</NavLink>
+            </div>
             {localStorage.getItem("safeDishes") ? (
                 <div className="flex flex-col gap-10">
                     {/* Current Week menu */}
@@ -17,6 +19,6 @@ export default function Home() {
             ) : (
                 <p className="text-center">Set employee allergies before continuing</p>
             )}
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
# Description
Creates Generate Menu Page, calendar week selection, and "Generate Menu" on Home page

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
- I made a "Generate Menu" button was created on the Home page to send users to Generate Menu page.
- I made a Generate Menu page that will include the calendar, on/off checkbox, "Generate" button, and "Regenerate" button. 
- I used moment and react-day-picker to build a interactive calendar.
- When a date is selected on the calendar, it will produce an array of 7 dates that includes the selected date. The array will be listed from Monday ( array[0] ) to Sunday ( array[6] ).
- Styling is yet to be done.

## Related Issues

In-Progress - MSAC-38 Select a date from date picker to generate menus for that week

## Testing instructions
- Press "Generate Menu" button from Home page to be taken to Generate Menu page.
- Open Console.
- Press "test" button to see that selected days are empty initially.
- Select any day from the calendar to see the array of days. (logged by Calendar.jsx)
- Press "test" button after date selection to see the array of days. (logged by GenerateMenu.jsx)

## Screenshots (if applicable)
![화면 캡처 2025-01-23 070110](https://github.com/user-attachments/assets/f051363b-8586-45f2-a251-0a6d0dc0192e)
