### PR TITLE
Feature/Off-days checkbox and Current dates

### DIFF
--- a/src/components/weekly-menu/WeeklyMenu.jsx
+++ b/src/components/weekly-menu/WeeklyMenu.jsx
@@ -1,17 +1,41 @@
 /* eslint-disable react/prop-types -- bypass proptypes error */
 import { DayCard } from "./DayCard";
 import useGenerateWeeklyDishes from "../../hooks/useGenerateWeeklyDishes";
+import moment from "moment";
+import { useState, useEffect } from "react";
+import getWeekDays from "../../functions/getWeekDays.js";
+
+//looks at today's date and produce an array of days of the current week
+function getWeekLabels(weekStart) {
+      const days = [];
+    
+      for (let i = 0; i < 7; i += 1) {
+        //changes DATE data into a STRING and removes time data (ex: "Mon Jan 20 2025")
+        days.push(moment(weekStart).add(i, "days").toString().slice(0, 15));
+      }
+
+      return days;
+}
+
 export function WeeklyMenu({ week }) {
     const currentWeekDishes = useGenerateWeeklyDishes();
-    const days = ["Mon", "Tues", "Wed", "Thurs", "Fri", "Sat", "Sun"]; // temp data for days of week
+    const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([])
+    const [currentWeekDays, setCurrentWeekDays] = useState([])
+
+    //populates currentWeekDaysLabels and currentWeekDays at component render
+    useEffect(() => {
+        setCurrentWeekDaysLabels(getWeekLabels(moment().startOf('isoWeek')))
+        setCurrentWeekDays(getWeekDays(moment().startOf('isoWeek')))
+    },[])
 
     return (
         <>
             <div className="gap-14 bg-slate-100 p-6">
                 <h2 className="text-center my-8">{week === "current" ? "This" : "Upcoming"} Week&apos;s Menu</h2>
+                <button onClick={() => console.log(currentWeekDays)}>test</button>
                 <div className="grid grid-cols-4 gap-6">
                     {Array.from(currentWeekDishes).map((dish, i) => (
-                        <DayCard key={i} dish={dish} day={days[i]} />
+                        <DayCard key={i} dish={dish} day={currentWeekDaysLabels[i]} />
                     ))}
                 </div>
             </div>

--- a/src/functions/getWeekDays.js
+++ b/src/functions/getWeekDays.js
@@ -5,7 +5,7 @@ export default function getWeekDays(weekStart) {
     
       for (let i = 0; i < 7; i += 1) {
         //changes DATE data into an ISO date format STRING and keeps only yyyy-mm-dd (ex: "2025-01-23")
-        days.push(moment(weekStart).add(i, "days").toDate().toISOString().slice(0, 10));
+        days.push(moment(weekStart).add(i, "days").toISOString().slice(0, 10));
       }
 
       return days;

--- a/src/pages/GenerateMenu.jsx
+++ b/src/pages/GenerateMenu.jsx
@@ -2,13 +2,28 @@ import React from 'react'
 import Calendar from '../components/Calendar.jsx'
 import {useState} from 'react'
 
+
+
 export default function GenerateMenu() {
 
     const [selectedDaysFromCalendar, setSelectedDaysFromCalendar] = useState([])
 
+    //initially Sat and Sun are checked as off days
+    const [offDays, setOffDays] = useState([false,false,false,false,false,true,true])
+
     const handleSelectedDaysUpdate = (days) => {
         setSelectedDaysFromCalendar(days)
     }
+
+    //updates the offDays array whenever a checkbox is checked/unchecked
+    const handleCheckboxChange = (index) => {
+        setOffDays((prevOffDays) => {
+          const updatedOffDays = [...prevOffDays];
+          updatedOffDays[index] = !updatedOffDays[index];
+          return updatedOffDays;
+        });
+      };
+
   return (
     <div className="w-screen">
         <h2 className="text-center m-4">Generate Menu</h2>
@@ -18,10 +33,40 @@ export default function GenerateMenu() {
                 <span className="text-center items-center m-2">Choose a week to generate a menu for</span>
                 <Calendar onSelectedDaysChange={handleSelectedDaysUpdate}/>
             </div>
-            <div>
-
+            <div className="flex flex-col items-center w-full">
+                <h2 className="text-center items-center m-3">Days Off</h2>
+                <form type="submit" className="flex flex-row justify-center w-full">
+                    <div className="px-3">
+                        <input type="checkbox" id="mon" key="mon" checked={offDays[0]} onChange={() => handleCheckboxChange(0)}/>
+                        <label> Mon</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="tue" key="tue" checked={offDays[1]} onChange={() => handleCheckboxChange(1)}/>
+                        <label> Tue</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="wed" key="wed" checked={offDays[2]} onChange={() => handleCheckboxChange(2)}/>
+                        <label> Wed</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="thu" key="thu" checked={offDays[3]} onChange={() => handleCheckboxChange(3)}/>
+                        <label> Thu</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="fri" key="fri" checked={offDays[4]} onChange={() => handleCheckboxChange(4)}/>
+                        <label> Fri</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="sat" key="sat" checked={offDays[5]} onChange={() => handleCheckboxChange(5)}/>
+                        <label> Sat</label>
+                    </div>
+                    <div className="px-3">
+                        <input type="checkbox" id="sun" key="sun" checked={offDays[6]} onChange={() => handleCheckboxChange(6)}/>
+                        <label> Sun</label>
+                    </div>
+                </form>
             </div>
-        <button onClick={() => console.log(selectedDaysFromCalendar)}>test</button>
+        <button onClick={() => {console.log(selectedDaysFromCalendar);console.log(offDays)}}>test</button>
 
         </div>
     </div>


### PR DESCRIPTION
# Description
Creates off-day checkbox in Generate Menu page and current week date labels for Home page

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
- Built 7 checkbox for Mon to Sun which will produce an array of 7 boolean values.
- Created labels for days of the week on Home page that will reflect the current week.

## Related Issues
In-Progress - MSAC-38 Select a date from date picker to generate menus for that week

## Testing instructions
- On Generate Menu page, check and uncheck the checkbox and press "test"
- Console will display an empty array for the week selection (if a week hasn't been selected in calendar) and an array with 7 boolean values (boolean answers the question "day off?")

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/ae6483b7-76f6-4fa8-9115-9b9f5bf49247)