### PR TITLE
Feature/Home-page-current-upcoming-week-label

### DIFF
--- a/src/components/weekly-menu/WeeklyMenu.jsx
+++ b/src/components/weekly-menu/WeeklyMenu.jsx
@@ -17,21 +17,21 @@ function getWeekLabels(weekStart) {
       return days;
 }
 
-export function WeeklyMenu({ week }) {
+export function WeeklyMenu({ weekStartDay }) {
     const currentWeekDishes = useGenerateWeeklyDishes();
     const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([])
     const [currentWeekDays, setCurrentWeekDays] = useState([])
 
     //populates currentWeekDaysLabels and currentWeekDays at component render
     useEffect(() => {
-        setCurrentWeekDaysLabels(getWeekLabels(moment().startOf('isoWeek')))
-        setCurrentWeekDays(getWeekDays(moment().startOf('isoWeek')))
+        setCurrentWeekDaysLabels(getWeekLabels(weekStartDay))
+        setCurrentWeekDays(getWeekDays(weekStartDay))
     },[])
 
     return (
         <>
             <div className="gap-14 bg-slate-100 p-6">
-                <h2 className="text-center my-8">{week === "current" ? "This" : "Upcoming"} Week&apos;s Menu</h2>
+                <h2 className="text-center my-8">{getWeekDays(weekStartDay).includes(moment().toISOString().slice(0, 10)) ? "This" : "Upcoming"} Week&apos;s Menu</h2>
                 <button onClick={() => console.log(currentWeekDays)}>test</button>
                 <div className="grid grid-cols-4 gap-6">
                     {Array.from(currentWeekDishes).map((dish, i) => (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import { WeeklyMenu } from "../components/weekly-menu/WeeklyMenu";
 import { NavLink } from "react-router-dom";
+import moment from "moment";
 
 
 export default function Home() {
@@ -11,10 +12,10 @@ export default function Home() {
             {localStorage.getItem("safeDishes") ? (
                 <div className="flex flex-col gap-10">
                     {/* Current Week menu */}
-                    <WeeklyMenu week={"current"} />
+                    <WeeklyMenu weekStartDay={moment().startOf('isoWeek')} />
 
                     {/* Upcoming Week menu */}
-                    <WeeklyMenu week={"upcoming"} />
+                    <WeeklyMenu weekStartDay={moment().add(7,"days").startOf('isoWeek')} />
                 </div>
             ) : (
                 <p className="text-center">Set employee allergies before continuing</p>


### PR DESCRIPTION
# Description
Creates updated Home page week days labels for current and next week

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
- Created logic for displaying current week days' and upcoming week days' labels

## Related Issues

Closes #[Jira issue number]

## Testing instructions
- See days' labels on Home page

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b56b0c59-7c14-4728-b7a6-aa7d157d1451)