### PR TITLE
Add regenerate feature to weekly menu. Add temp button on home page for testing regenerate function

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default [
             "react-refresh": reactRefresh,
         },
         rules: {
-            "react/prop-types": 0,
+            "react/prop-types": "off",
             ...js.configs.recommended.rules,
             ...react.configs.recommended.rules,
             ...react.configs["jsx-runtime"].rules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,12 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.17.0",
-        "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "postcss": "^8.5.1",
+        "prop-types": "^15.8.1",
         "tailwindcss": "^3.4.17",
         "vite": "^6.0.5"
       }
@@ -3071,7 +3072,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
       "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -5024,7 +5024,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.1",
-
     "moment": "^2.30.1",
-
     "react": "^18.3.1",
     "react-day-picker": "^9.5.0",
     "react-dom": "^18.3.1",
@@ -31,11 +28,12 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",
-    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
     "postcss": "^8.5.1",
+    "prop-types": "^15.8.1",
     "tailwindcss": "^3.4.17",
     "vite": "^6.0.5"
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ function App() {
             children: [
                 {
                     path: "",
+                    loader: dataDishesLoader,
                     element: <Home />,
                 },
                 {

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,72 +1,68 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import moment from "moment";
-import {DayPicker} from "react-day-picker";
+import { DayPicker } from "react-day-picker";
 import getWeekDays from "../functions/getWeekDays.js";
-
 
 //returns an object with the start and end of a week by looking at the date selected
 function getWeekRange(date) {
-  return {
-    from: moment(date).startOf("isoWeek").toDate(),
-    to: moment(date).endOf("isoWeek").toDate(),
-  };
+    return {
+        from: moment(date).startOf("isoWeek").toDate(),
+        to: moment(date).endOf("isoWeek").toDate(),
+    };
 }
 
-export default function Calendar({onSelectedDaysChange}) {
-  const [hoverRange, setHoverRange] = useState(undefined);
-  const [selectedDays, setSelectedDays] = useState([]);
+export default function Calendar({ onSelectedDaysChange }) {
+    const [hoverRange, setHoverRange] = useState(undefined);
+    const [selectedDays, setSelectedDays] = useState([]);
 
-  //takes in selected date to obtain array from getWeekDays to be raised to GenerateMenu
-  const handleDayChange = (date) => {
-    setSelectedDays(getWeekDays(getWeekRange(date).from));
-    onSelectedDaysChange(getWeekDays(getWeekRange(date).from))
-    console.log(getWeekDays(getWeekRange(date).from))
-  };
+    //takes in selected date to obtain array from getWeekDays to be raised to GenerateMenu
+    const handleDayChange = (date) => {
+        setSelectedDays(getWeekDays(getWeekRange(date).from));
+        onSelectedDaysChange(getWeekDays(getWeekRange(date).from));
+        console.log(getWeekDays(getWeekRange(date).from));
+    };
 
-  const handleDayEnter = (date) => {
-    setHoverRange(getWeekRange(date));
-  };
+    const handleDayEnter = (date) => {
+        setHoverRange(getWeekRange(date));
+    };
 
-  const handleDayLeave = () => {
-    setHoverRange(undefined);
-  };
+    const handleDayLeave = () => {
+        setHoverRange(undefined);
+    };
 
+    const daysAreSelected = selectedDays.length > 0;
 
-  const daysAreSelected = selectedDays.length > 0;
+    //TO-DO understand this
+    const modifiers = {
+        hoverRange,
+        selectedRange: daysAreSelected && {
+            from: selectedDays[0],
+            to: selectedDays[6],
+        },
+        hoverRangeStart: hoverRange && hoverRange.from,
+        hoverRangeEnd: hoverRange && hoverRange.to,
+        selectedRangeStart: daysAreSelected && selectedDays[0],
+        selectedRangeEnd: daysAreSelected && selectedDays[6],
+    };
 
-  //TO-DO understand this
-  const modifiers = {
-    hoverRange,
-    selectedRange: daysAreSelected && {
-      from: selectedDays[0],
-      to: selectedDays[6],
-    },
-    hoverRangeStart: hoverRange && hoverRange.from,
-    hoverRangeEnd: hoverRange && hoverRange.to,
-    selectedRangeStart: daysAreSelected && selectedDays[0],
-    selectedRangeEnd: daysAreSelected && selectedDays[6],
-  };
-
-  return (
-    <div className="w-1/3 space-y-4 p-4 bg-gray-100 rounded-lg shadow">
-      <DayPicker
-        weekStartsOn={1}
-        //disabled={{ before: new Date() }}
-        selectedDays={selectedDays}
-        showOutsideDays={false}
-        modifiers={modifiers}
-        onDayClick={handleDayChange}
-        onDayMouseEnter={handleDayEnter}
-        onDayMouseLeave={handleDayLeave}
-        className=" w-full border border-gray-300 rounded-lg bg-white flex flex-row justify-center"
-      />
-      {selectedDays.length === 7 && (
-        <div className="text-center text-lg font-medium text-gray-800">
-          {moment(selectedDays[0]).format("LL")} –{" "}
-          {moment(selectedDays[6]).format("LL")}
+    return (
+        <div className="w-1/3 space-y-4 p-4 bg-gray-100 rounded-lg shadow">
+            <DayPicker
+                weekStartsOn={1}
+                //disabled={{ before: new Date() }}
+                selectedDays={selectedDays}
+                showOutsideDays={false}
+                modifiers={modifiers}
+                onDayClick={handleDayChange}
+                onDayMouseEnter={handleDayEnter}
+                onDayMouseLeave={handleDayLeave}
+                className=" w-full border border-gray-300 rounded-lg bg-white flex flex-row justify-center"
+            />
+            {selectedDays.length === 7 && (
+                <div className="text-center text-lg font-medium text-gray-800">
+                    {moment(selectedDays[0]).format("LL")} – {moment(selectedDays[6]).format("LL")}
+                </div>
+            )}
         </div>
-      )}
-      
-    </div>
-  );
+    );
 }

--- a/src/components/weekly-menu/WeeklyMenu.jsx
+++ b/src/components/weekly-menu/WeeklyMenu.jsx
@@ -1,40 +1,41 @@
 /* eslint-disable react/prop-types -- bypass proptypes error */
 import { DayCard } from "./DayCard";
-import useGenerateWeeklyDishes from "../../hooks/useGenerateWeeklyDishes";
-import moment from "moment";
 import { useState, useEffect } from "react";
+import moment from "moment";
 import getWeekDays from "../../functions/getWeekDays.js";
 
 //looks at today's date and produce an array of days of the current week
 function getWeekLabels(weekStart) {
-      const days = [];
-    
-      for (let i = 0; i < 7; i += 1) {
+    const days = [];
+
+    for (let i = 0; i < 7; i += 1) {
         //changes DATE data into a STRING and removes time data (ex: "Mon Jan 20 2025")
         days.push(moment(weekStart).add(i, "days").toString().slice(0, 15));
-      }
+    }
 
-      return days;
+    return days;
 }
 
-export function WeeklyMenu({ weekStartDay }) {
-    const currentWeekDishes = useGenerateWeeklyDishes();
-    const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([])
-    const [currentWeekDays, setCurrentWeekDays] = useState([])
+export function WeeklyMenu({ weekStartDay, dishes }) {
+    const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([]);
+    const [currentWeekDays, setCurrentWeekDays] = useState([]);
 
     //populates currentWeekDaysLabels and currentWeekDays at component render
     useEffect(() => {
-        setCurrentWeekDaysLabels(getWeekLabels(weekStartDay))
-        setCurrentWeekDays(getWeekDays(weekStartDay))
-    },[])
+        setCurrentWeekDaysLabels(getWeekLabels(weekStartDay));
+        setCurrentWeekDays(getWeekDays(weekStartDay));
+    }, []);
 
     return (
         <>
             <div className="gap-14 bg-slate-100 p-6">
-                <h2 className="text-center my-8">{getWeekDays(weekStartDay).includes(moment().toISOString().slice(0, 10)) ? "This" : "Upcoming"} Week&apos;s Menu</h2>
+                <h2 className="text-center my-8">
+                    {getWeekDays(weekStartDay).includes(moment().toISOString().slice(0, 10)) ? "This" : "Upcoming"}{" "}
+                    Week&apos;s Menu
+                </h2>
                 <button onClick={() => console.log(currentWeekDays)}>test</button>
                 <div className="grid grid-cols-4 gap-6">
-                    {Array.from(currentWeekDishes).map((dish, i) => (
+                    {Array.from(dishes || []).map((dish, i) => (
                         <DayCard key={i} dish={dish} day={currentWeekDaysLabels[i]} />
                     ))}
                 </div>

--- a/src/hooks/useGenerateWeeklyDishes.js
+++ b/src/hooks/useGenerateWeeklyDishes.js
@@ -1,5 +1,34 @@
+// import { useState } from "react";
+import { useLocalStorage } from "./useLocalStorage";
+import { useLoaderData } from "react-router-dom";
+
 import getSafeDishesFromLocal from "../functions/getSafeDishesFromLocal";
 
 export default function useGenerateWeeklyDishes() {
-    return getSafeDishesFromLocal().slice(0, 7);
+    const fetchDishes = useLoaderData();
+    const [menuDishes, setDishes] = useLocalStorage("menuDishes", {});
+
+    function setMenuDishes() {
+        const safeDishes = getSafeDishesFromLocal();
+
+        function randomizeSortSlice(array) {
+            console.log(array.length);
+            return array.sort(() => Math.random() - 0.5).slice(0, 7);
+        }
+        if (!safeDishes || safeDishes.length === 0) {
+            setDishes({
+                currentWeek: randomizeSortSlice(fetchDishes),
+                nextWeek: randomizeSortSlice(fetchDishes),
+            });
+            return;
+        } else {
+            setDishes({
+                currentWeek: randomizeSortSlice(getSafeDishesFromLocal()),
+                nextWeek: randomizeSortSlice(getSafeDishesFromLocal()),
+            });
+        }
+    }
+
+    console.log(menuDishes);
+    return [menuDishes, setMenuDishes];
 }

--- a/src/pages/Allergies.jsx
+++ b/src/pages/Allergies.jsx
@@ -1,161 +1,151 @@
 import { useLoaderData } from "react-router-dom";
+import { useState } from "react";
+import Select, { components } from "react-select";
+
+import { useLocalStorage } from "../hooks/useLocalStorage";
+import { customStyles } from "../data/customStyles";
 import { ALLERGENS } from "../data/allergens";
 import { INITIAL_EMPLOYEE_DATA } from "../data/initialEmployeeData";
-import { useLocalStorage } from "../hooks/useLocalStorage";
+
 import DeleteIcon from "@mui/icons-material/Delete";
 import ModeEditOutlineOutlinedIcon from "@mui/icons-material/ModeEditOutlineOutlined";
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
-import Select, { components } from "react-select";
 import identifySafeDishes from "../functions/identifySafeDishes";
-import { useState } from "react";
-import { customStyles } from "../data/customStyles";
 
 export default function Allergies() {
-  const fetchDishes = useLoaderData();
-  const [employeesData, setEmployeesData] = useLocalStorage(
-    "employeesData",
-    INITIAL_EMPLOYEE_DATA
-  );
-  const [safeDishes, setSafeDishes] = useLocalStorage("safeDishes", []);
-  const [editingEmployee, setEditingEmployee] = useState(null);
-  const [isEmployeeMenuOpen, setIsEmployeeMenuOpen] = useState(null);
-  // const [openMenu, setOpenMenu] = useState(false);
+    // TODO: when allergy data changes, update the menuDishes object in local
+    // storage instead of waiting to update when the Home page mounts
+    const fetchDishes = useLoaderData();
+    const [employeesData, setEmployeesData] = useLocalStorage("employeesData", INITIAL_EMPLOYEE_DATA);
+    const [safeDishes, setSafeDishes] = useLocalStorage("safeDishes", []);
+    const [editingEmployee, setEditingEmployee] = useState(null);
+    const [isEmployeeMenuOpen, setIsEmployeeMenuOpen] = useState(null);
+    // const [openMenu, setOpenMenu] = useState(false);
 
-  function updateEmployeeAllergies(selectedEmployee, selectedOptions) {
-    const updatedEmployeesData = employeesData.map((employee) => {
-      if (employee.name === selectedEmployee.name) {
-        employee.allergies = selectedOptions.map((allergy) => {
-          return { value: allergy.value, label: allergy.label };
+    function updateEmployeeAllergies(selectedEmployee, selectedOptions) {
+        const updatedEmployeesData = employeesData.map((employee) => {
+            if (employee.name === selectedEmployee.name) {
+                employee.allergies = selectedOptions.map((allergy) => {
+                    return { value: allergy.value, label: allergy.label };
+                });
+            }
+            return employee;
         });
-      }
-      return employee;
-    });
-    //save update employees allergies to local storage
-    setEmployeesData(updatedEmployeesData);
-    //filter employees with allergies
-    const employeesWithAllergies = updatedEmployeesData.filter(
-      (employee) => employee.allergies.length > 0
+        //save update employees allergies to local storage
+        setEmployeesData(updatedEmployeesData);
+        //filter employees with allergies
+        const employeesWithAllergies = updatedEmployeesData.filter((employee) => employee.allergies.length > 0);
+        const employeesAllergens = employeesWithAllergies.map((employee) =>
+            employee.allergies.flatMap((allergy) => {
+                if (
+                    allergy.label === "Fish" ||
+                    allergy.label === "Gluten" ||
+                    allergy.label === "Dairy" ||
+                    allergy.label === "Shellfish"
+                ) {
+                    return allergy.value.split(" ").concat(allergy.label);
+                }
+                return allergy.value;
+            })
+        );
+        //list of allergens selected unique values
+        const uniqueAllergens = [...new Set(employeesAllergens.flat())];
+        //dishes safe for employees
+        const updatedSafeDishes = identifySafeDishes(fetchDishes, uniqueAllergens);
+        //save safe dishes to local storage
+        setSafeDishes(updatedSafeDishes);
+    }
+
+    function deleteAllergies(selectedEmployee) {
+        const updatedEmployeesData = employeesData.map((employee) => {
+            if (employee.name === selectedEmployee.name) {
+                employee.allergies = []; // Reset allergies
+            }
+            return employee;
+        });
+        setEmployeesData(updatedEmployeesData);
+        setEditingEmployee(null);
+    }
+
+    return (
+        <>
+            <h2 className="text-center m-4 text-[32px] font-normal">Allergies</h2>{" "}
+            <section className="flex flex-col w-full">
+                <ul className="flex flex-col items-center gap-4 text-[22px]">
+                    <li className="flex w-full items-center  gap-4">
+                        <span className="w-[427px] h-[70px] bg-indigo-100 flex justify-center items-center ">
+                            Employee Name
+                        </span>
+                        <span className="w-[427px]  h-[70px] bg-indigo-100 flex justify-center items-center">
+                            Allergy
+                        </span>
+                    </li>
+                    {employeesData.map((employee) => (
+                        <li className="flex w-full items-center  gap-4" key={employee.name}>
+                            <span className="w-[427px]  h-[70px] bg-indigo-100 flex justify-center items-center ">
+                                {employee.name}
+                            </span>
+                            <span className="w-[427px]  h-[70px] bg-indigo-100 relative">
+                                <Select
+                                    styles={customStyles}
+                                    onChange={(selectedOptions) => updateEmployeeAllergies(employee, selectedOptions)}
+                                    closeMenuOnSelect={false}
+                                    isMulti
+                                    options={ALLERGENS}
+                                    value={employee.allergies}
+                                    placeholder={"[Allergy]"}
+                                    isClearable={false}
+                                    isDisabled={employee.allergies.length > 0 && !isEmployeeMenuOpen}
+                                    onMenuOpen={() => {
+                                        setIsEmployeeMenuOpen(employee.name);
+                                        setEditingEmployee(employee.name);
+                                    }}
+                                    onMenuClose={() => {
+                                        setIsEmployeeMenuOpen(null);
+                                    }}
+                                    components={{
+                                        MultiValueRemove: (props) =>
+                                            editingEmployee === employee.name &&
+                                            isEmployeeMenuOpen === employee.name ? (
+                                                <components.MultiValueRemove {...props}>
+                                                    <DeleteIcon />
+                                                </components.MultiValueRemove>
+                                            ) : null,
+                                    }}
+                                />
+                                {isEmployeeMenuOpen !== employee.name && employee.allergies.length > 0 && (
+                                    <button
+                                        className="w-10  bg-indigo-100 text- flex justify-center items-center h-8 absolute right-2 top-1 "
+                                        onClick={(event) => {
+                                            setEditingEmployee(employee.name);
+                                            setIsEmployeeMenuOpen(employee.name);
+                                        }}>
+                                        <ModeEditOutlineOutlinedIcon fontSize="large" />
+                                    </button>
+                                )}
+                                {employee.allergies.length > 0 && employee.name === editingEmployee ? (
+                                    <button
+                                        className="w-10  bg-indigo-100 text- flex justify-center items-center h-8 absolute right-2 top-1 "
+                                        onClick={(event) => {
+                                            setEditingEmployee(null);
+                                        }}>
+                                        <SaveOutlinedIcon fontSize="large" />
+                                    </button>
+                                ) : (
+                                    ""
+                                )}
+                            </span>
+
+                            <button
+                                className="w-10  bg-white text- flex justify-center items-center h-8 rounded"
+                                onClick={(event) => deleteAllergies(employee)}
+                                title="Delete all allergies">
+                                <DeleteIcon fontSize="large" />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </>
     );
-    const employeesAllergens = employeesWithAllergies.map((employee) =>
-      employee.allergies.flatMap((allergy) => {
-        if (
-          allergy.label === "Fish" ||
-          allergy.label === "Gluten" ||
-          allergy.label === "Dairy" ||
-          allergy.label === "Shellfish"
-        ) {
-          return allergy.value.split(" ").concat(allergy.label);
-        }
-        return allergy.value;
-      })
-    );
-    //list of allergens selected unique values
-    const uniqueAllergens = [...new Set(employeesAllergens.flat())];
-    //dishes safe for employees
-    const updatedSafeDishes = identifySafeDishes(fetchDishes, uniqueAllergens);
-    //save safe dishes to local storage
-    setSafeDishes(updatedSafeDishes);
-  }
-
-  function deleteAllergies(selectedEmployee) {
-    const updatedEmployeesData = employeesData.map((employee) => {
-      if (employee.name === selectedEmployee.name) {
-        employee.allergies = []; // Reset allergies
-      }
-      return employee;
-    });
-    setEmployeesData(updatedEmployeesData);
-    setEditingEmployee(null);
-  }
-
-  return (
-    <>
-      <h2 className="text-center m-4 text-[32px] font-normal">Allergies</h2>{" "}
-      <section className="flex flex-col w-full">
-        <ul className="flex flex-col items-center gap-4 text-[22px]">
-          <li className="flex w-full items-center  gap-4">
-            <span className="w-[427px] h-[70px] bg-indigo-100 flex justify-center items-center ">
-              Employee Name
-            </span>
-            <span className="w-[427px]  h-[70px] bg-indigo-100 flex justify-center items-center">
-              Allergy
-            </span>
-          </li>
-          {employeesData.map((employee) => (
-            <li className="flex w-full items-center  gap-4" key={employee.name}>
-              <span className="w-[427px]  h-[70px] bg-indigo-100 flex justify-center items-center ">
-                {employee.name}
-              </span>
-              <span className="w-[427px]  h-[70px] bg-indigo-100 relative">
-                <Select
-                  styles={customStyles}
-                  onChange={(selectedOptions) =>
-                    updateEmployeeAllergies(employee, selectedOptions)
-                  }
-                  closeMenuOnSelect={false}
-                  isMulti
-                  options={ALLERGENS}
-                  value={employee.allergies}
-                  placeholder={"[Allergy]"}
-                  isClearable={false}
-                  isDisabled={
-                    employee.allergies.length > 0 && !isEmployeeMenuOpen
-                  }
-                  onMenuOpen={() => {
-                    setIsEmployeeMenuOpen(employee.name);
-                    setEditingEmployee(employee.name);
-                  }}
-                  onMenuClose={() => {
-                    setIsEmployeeMenuOpen(null);
-                  }}
-                  components={{
-                    MultiValueRemove: (props) =>
-                      editingEmployee === employee.name &&
-                      isEmployeeMenuOpen === employee.name ? (
-                        <components.MultiValueRemove {...props}>
-                          <DeleteIcon />
-                        </components.MultiValueRemove>
-                      ) : null,
-                  }}
-                />
-                {isEmployeeMenuOpen !== employee.name &&
-                  employee.allergies.length > 0 && (
-                    <button
-                      className="w-10  bg-indigo-100 text- flex justify-center items-center h-8 absolute right-2 top-1 "
-                      onClick={(event) => {
-                        setEditingEmployee(employee.name);
-                        setIsEmployeeMenuOpen(employee.name);
-                      }}
-                    >
-                      <ModeEditOutlineOutlinedIcon fontSize="large" />
-                    </button>
-                  )}
-                {employee.allergies.length > 0 &&
-                employee.name === editingEmployee ? (
-                  <button
-                    className="w-10  bg-indigo-100 text- flex justify-center items-center h-8 absolute right-2 top-1 "
-                    onClick={(event) => {
-                      setEditingEmployee(null);
-                    }}
-                  >
-                    <SaveOutlinedIcon fontSize="large" />
-                  </button>
-                ) : (
-                  ""
-                )}
-              </span>
-
-              <button
-                className="w-10  bg-white text- flex justify-center items-center h-8 rounded"
-                onClick={(event) => deleteAllergies(employee)}
-                title="Delete all allergies"
-              >
-                <DeleteIcon fontSize="large" />
-              </button>
-            </li>
-          ))}
-        </ul>
-      </section>
-    </>
-  );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,25 +1,42 @@
 import { WeeklyMenu } from "../components/weekly-menu/WeeklyMenu";
 import { NavLink } from "react-router-dom";
-import moment from "moment";
+import { useEffect } from "react";
 
+import moment from "moment";
+import useGenerateWeeklyDishes from "../hooks/useGenerateWeeklyDishes";
 
 export default function Home() {
+    const [menuDishes, setMenuDishes] = useGenerateWeeklyDishes();
+
+    useEffect(() => {
+        // Temporary -- generates a menu on mount
+        if (!localStorage.getItem("menuDishes")) setMenuDishes();
+    }, []);
+
     return (
         <div className="flex flex-col items-center">
             <div className="flex flex-row w-full justify-end">
-                <NavLink className="bg-blue-400 rounded-3xl p-3 m-3 w-1/6 text-center  hover:bg-gray-200" to={"/GenerateMenu"}>+ Generate Menu</NavLink>
+                <NavLink
+                    className="bg-blue-400 rounded-3xl p-3 m-3 w-1/6 text-center  hover:bg-gray-200"
+                    to={"/GenerateMenu"}>
+                    + Generate Menu
+                </NavLink>
             </div>
-            {localStorage.getItem("safeDishes") ? (
-                <div className="flex flex-col gap-10">
-                    {/* Current Week menu */}
-                    <WeeklyMenu weekStartDay={moment().startOf('isoWeek')} />
+            <div className="flex flex-row w-full justify-end">
+                <NavLink
+                    className="bg-blue-400 rounded-3xl p-3 m-3 w-1/6 text-center  hover:bg-gray-200"
+                    onClick={() => setMenuDishes()}>
+                    Test Regenerate Menu
+                </NavLink>
+            </div>
 
-                    {/* Upcoming Week menu */}
-                    <WeeklyMenu weekStartDay={moment().add(7,"days").startOf('isoWeek')} />
-                </div>
-            ) : (
-                <p className="text-center">Set employee allergies before continuing</p>
-            )}
+            <div className="flex flex-col gap-10">
+                {/* Current Week menu */}
+                <WeeklyMenu weekStartDay={moment().startOf("isoWeek")} dishes={menuDishes.currentWeek} />
+
+                {/* Upcoming Week menu */}
+                <WeeklyMenu weekStartDay={moment().add(7, "days").startOf("isoWeek")} dishes={menuDishes.nextWeek} />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
# Description
<!-- Explain the change done in one-sentence -->
Add regenerate menu functionality
## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
<!-- Provide a concise summary of the changes and the purpose of this pull request. -->
- Add button to test regenerate
- Update useGenerateWeeklyDish function to fetch safeDishes from local storage(or use all dishes from API if safeDishes does not exist yet), randomize and spit out weekly menus for current week and the following week. 
## Related Issues

Closes #MSAC-60

## Testing instructions
<!-- Instructions on how to test the changes made in the pull 
request, helping reviewers validate the code. -->

## Screenshots (if applicable)
<!-- Add screenshots here to demonstrate the UI changes. -->