### PR TITLE
Refactor: Remove duplicates from the weekly lunch menu

### DIFF
--- a/src/functions/removeDuplicateDishes.js
+++ b/src/functions/removeDuplicateDishes.js
@@ -1,0 +1,50 @@
+
+function countOccurrences(arr, value) {
+    let count = 0;
+    for (let element of arr) {
+        if (element.name === value.name) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/**
+ * Takes an array of all dishes and an array of 7 dishes and replaces any dishes 
+ * that appear more then once in the 7 dishes array with a random dish from the 
+ * all dishes array. 
+ * 
+ * The function returns the 7 dishes array with no duplicates.
+ * @param {object[]} allDishes Array of all dishes
+ * @param {object[]} sevenDishes Array of 7 dishes
+ * @returns {object[]} Array of 7 dishes with no duplicates
+ */
+export default function removeDuplicateDishes(allDishes, sevenDishes) {
+    let duplicates = true;
+    let currentArray = [...sevenDishes]; // Start with original array
+
+    while (duplicates) {
+        duplicates = false; // Reset flag at start of each check
+        let newArray = [];
+        
+        currentArray.forEach((dish) => {
+            const numberOfOccur = countOccurrences(currentArray, dish);
+
+            if (numberOfOccur > 1 && !newArray.some(d => d.name === dish.name)) {
+                duplicates = true;
+                let replacementDish;
+                do {
+                    const randomNumber = Math.floor(Math.random() * allDishes.length);
+                    replacementDish = allDishes[randomNumber];
+                } while (currentArray.some(d => d.name === replacementDish.name));
+                newArray.push(replacementDish);
+            } else if (!newArray.some(d => d.name === dish.name)) {
+                newArray.push(dish);
+            }
+        });
+
+        currentArray = newArray; // Update current array for next iteration
+    }
+
+    return currentArray;
+}

--- a/src/hooks/useGenerateWeeklyDishes.js
+++ b/src/hooks/useGenerateWeeklyDishes.js
@@ -3,6 +3,7 @@ import { useLocalStorage } from "./useLocalStorage";
 import { useLoaderData } from "react-router-dom";
 
 import getSafeDishesFromLocal from "../functions/getSafeDishesFromLocal";
+import removeDuplicateDishes from "../functions/removeDuplicateDishes";
 
 export default function useGenerateWeeklyDishes() {
     const fetchDishes = useLoaderData();
@@ -10,7 +11,6 @@ export default function useGenerateWeeklyDishes() {
 
     function setMenuDishes() {
         const safeDishes = getSafeDishesFromLocal();
-
         function randomizeSortSlice(array) {
             console.log(array.length);
             return array.sort(() => Math.random() - 0.5).slice(0, 7);
@@ -23,8 +23,8 @@ export default function useGenerateWeeklyDishes() {
             return;
         } else {
             setDishes({
-                currentWeek: randomizeSortSlice(getSafeDishesFromLocal()),
-                nextWeek: randomizeSortSlice(getSafeDishesFromLocal()),
+                currentWeek: removeDuplicateDishes(safeDishes, randomizeSortSlice(getSafeDishesFromLocal())),
+                nextWeek: removeDuplicateDishes(safeDishes, randomizeSortSlice(getSafeDishesFromLocal())),
             });
         }
     }


### PR DESCRIPTION
# Description
Refactor the weekly menu dishes to ensure there aren't any duplicates

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
Create a new function that takes the original dishes from the weekly dishes and check for duplicates. If a duplicate is found, then a random dish from the database of safe dishes is substituted. A new weekly dish menu is returned. 

## Related Issues

Closes #69

## Testing instructions
On the home page, this week's and next week's menu shouldn't contain a duplicate. Next press the regenerate button to ensure its new menus don't contain duplicates. 

## Screenshots (if applicable)
No UI changes. 