### PR TITLE
Add an accessible label to the Select elements for each employee

### DIFF
--- a/src/pages/Allergies.jsx
+++ b/src/pages/Allergies.jsx
@@ -165,6 +165,7 @@ export default function Allergies() {
               <div className="w-1/2 flex justify-between items-center">
                 <span className="w-[85%] md:w-[90%] bg-white relative shadow-md">
                   <Select
+                    aria-label = {`Allergies for ${employee.name}`}
                     onBlur={() => {
                       setOpenDropDown(false);
                     }}


### PR DESCRIPTION
# Description
In response to a less then 100% score on the Chrome's Accessibility report, labels have been applied to Select elements that attach allergies to employees on the Allergies page. 

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues
N/A

## Testing instructions
Open the app on the Chrome browser and go to the Allergies page. Once there, locate the Accessibility tab within the Lighthouse section of the Chrome's browser's toolkit. Run the report and you shouldn't see any issues related to labels for input fields. 

## Screenshots (if applicable)
