### PR TITLE
Feature/Dropdown of dates to see other weeks on Home page

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -56,10 +56,10 @@ export default function Calendar({ onSelectedDaysChange, onOffDaysChange, onTrue
                 })
               : false,
         }}
-        disabled={[
+        /*disabled={[
           { dayOfWeek: offDaysDisabled },
           { before: startOfWeek(new Date(), { weekStartsOn: 1 }) },
-        ]}
+        ]}*/
         onDayClick={handleDayClick}
       />
       {selectedDays && (

--- a/src/components/weekly-menu/WeeklyMenu.jsx
+++ b/src/components/weekly-menu/WeeklyMenu.jsx
@@ -1,86 +1,104 @@
 /* eslint-disable react/prop-types -- bypass proptypes error */
 import { DayCard } from "./DayCard";
-import { formatISO9075, addDays, format } from "date-fns";
+import { formatISO9075, addDays, format, startOfWeek, isEqual } from "date-fns";
 import { useState, useEffect } from "react";
 
 //looks at today's date and produce an array of days of the current week
 function getWeekLabels(weekStart) {
-    const days = [];
+  const days = [];
 
-    for (let i = 0; i < 7; i += 1) {
-        //changes DATE data into a STRING and removes time data (ex: "Mon Jan 20 2025")
-        days.push(format(addDays(weekStart, i), "EEE MMM-dd-yyyy"));
-    }
+  for (let i = 0; i < 7; i += 1) {
+    //changes DATE data into a STRING and removes time data (ex: "Mon Jan 20 2025")
+    days.push(format(addDays(weekStart, i), "EEE MMM-dd-yyyy"));
+  }
 
-    return days;
+  return days;
 }
 
 function getWeekDays(weekStart) {
-    const days = [];
+  const days = [];
 
-    for (let i = 0; i < 7; i += 1) {
-        //changes DATE data into an ISO date format STRING and keeps only yyyy-mm-dd (ex: "2025-01-23")
-        days.push(formatISO9075(addDays(weekStart, i), { representation: "date" }));
-    }
+  for (let i = 0; i < 7; i += 1) {
+    //changes DATE data into an ISO date format STRING and keeps only yyyy-mm-dd (ex: "2025-01-23")
+    days.push(formatISO9075(addDays(weekStart, i), { representation: "date" }));
+  }
 
-    return days;
+  return days;
 }
 
 export function WeeklyMenu({ weekStartDay }) {
-    const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([]);
-    const [currentWeekDays, setCurrentWeekDays] = useState([]);
-    const [initialReady, setInitialReady] = useState([false]);
+  const [currentWeekDaysLabels, setCurrentWeekDaysLabels] = useState([]);
+  const [currentWeekDays, setCurrentWeekDays] = useState([]);
+  const [initialReady, setInitialReady] = useState(false);
 
-    // populates currentWeekDaysLabels and currentWeekDays at component render
-    useEffect(() => {
-        setCurrentWeekDaysLabels(getWeekLabels(weekStartDay));
-        setCurrentWeekDays(getWeekDays(weekStartDay));
-        setInitialReady(true);
-    }, []);
+  // populates currentWeekDaysLabels and currentWeekDays at component render
+  useEffect(() => {
+    setCurrentWeekDaysLabels(getWeekLabels(weekStartDay));
+    setCurrentWeekDays(getWeekDays(weekStartDay));
+    setInitialReady(true);
+  }, [weekStartDay]);
 
-    const storedWeeklyMenu = JSON.parse(localStorage.getItem("generatedWeeklyMenu"));
+  const storedWeeklyMenu = JSON.parse(
+    localStorage.getItem("generatedWeeklyMenu")
+  );
 
-    const [daysObjectsFromStorage, setDaysObjectsFromStorage] = useState([]);
+  const [daysObjectsFromStorage, setDaysObjectsFromStorage] = useState([]);
 
-    // runs only after initial useEffect due to dependancy
-    // runs only if local storage is NOT empty
-    useEffect(() => {
-        if (initialReady && storedWeeklyMenu !== null) {
-            const updatedStoredWeeklyMenu = storedWeeklyMenu.filter((x) => currentWeekDays.includes(x.id));
+  // runs only after initial useEffect due to dependancy
+  // runs only if local storage is NOT empty
+  useEffect(() => {
+    if (initialReady && storedWeeklyMenu !== null) {
+      console.log(initialReady);
+      const updatedStoredWeeklyMenu = storedWeeklyMenu.filter((x) =>
+        currentWeekDays.includes(x.id)
+      );
 
-            const daysObjects = [];
+      const daysObjects = [];
 
-            for (let i = 0; i < 7; i += 1) {
-                daysObjects.push(updatedStoredWeeklyMenu.find((x) => x.id === currentWeekDays[i]));
-            }
+      for (let i = 0; i < 7; i += 1) {
+        daysObjects.push(
+          updatedStoredWeeklyMenu.find((x) => x.id === currentWeekDays[i])
+        );
+      }
 
-            setDaysObjectsFromStorage(daysObjects);
-        }
-    }, [initialReady]);
+      setDaysObjectsFromStorage(daysObjects);
 
-    return (
-        <div className="flex flex-col items-around mt-1 mb-5 py-4 px-2 w-full bg-custom-blue">
+      setInitialReady(false);
+    }
+  }, [initialReady]);
 
-                <h2 className="text-center text-md md:text-2xl pb-5 underline">
-                    {getWeekDays(weekStartDay).includes(formatISO9075(new Date(), { representation: "date" }))
-                        ? "This"
-                        : "Upcoming"}{" "}
-                    Week&apos;s Menu
-                </h2>
 
-                <div className="flex flex-col md:grid md:grid-cols-4 w-full gap-3">
-                    {Array.from(daysObjectsFromStorage.length > 0 ? daysObjectsFromStorage : currentWeekDaysLabels).map(
-                        (object, i) => (
-                            <DayCard
-                                key={i}
-                                data={object !== undefined ? object : undefined}
-                                placeholder={"Menu Not Generated"}
-                                day={currentWeekDaysLabels[i]}
-                            />
-                        )
-                    )}
-                </div>
+  return (
+    <div className="flex flex-col items-around mt-1 mb-5 py-4 px-2 w-full bg-custom-blue">
+      <h2 className="text-center text-md md:text-2xl pb-5 underline">
+        {isEqual(weekStartDay, startOfWeek(new Date(), { weekStartsOn: 1 }))
+          ? "This Week's Menu"
+          : isEqual(
+              weekStartDay,
+              addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), 7)
+            )
+          ? "Upcoming Week's Menu"
+          : `${formatISO9075(weekStartDay, {
+              representation: "date",
+            })} ~ ${formatISO9075(addDays(weekStartDay, 6), {
+                representation: "date",
+              })}`}
+      </h2>
 
-        </div>
-    );
+      <div className="flex flex-col md:grid md:grid-cols-4 w-full gap-3">
+        {Array.from(
+          daysObjectsFromStorage.length > 0
+            ? daysObjectsFromStorage
+            : currentWeekDaysLabels
+        ).map((object, i) => (
+          <DayCard
+            key={i}
+            data={object !== undefined ? object : undefined}
+            placeholder={"Menu Not Generated"}
+            day={currentWeekDaysLabels[i]}
+          />
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/functions/generatePDF.js
+++ b/src/functions/generatePDF.js
@@ -13,13 +13,12 @@ function getWeekDays(weekStart) {
     return days;
   }
 
-export default function downloadMenuPDF() {
+export default function downloadMenuPDF(weekStart) {
 
-        const currentWeekDays = getWeekDays(
-          startOfWeek(new Date(), { weekStartsOn: 1 })
+        const currentWeekDays = getWeekDays(weekStart
         );
         const nextWeekDays = getWeekDays(
-          startOfWeek(addDays(new Date(), 7), {
+          startOfWeek(addDays(weekStart, 7), {
             weekStartsOn: 1,
           })
         );
@@ -44,12 +43,12 @@ export default function downloadMenuPDF() {
     
             const dayLabels = [];
     
-            if (title === "Current Week") {
+            if (title === "Selected Week") {
               for (let i = 0; i < 7; i += 1) {
                 //changes DATE data into a STRING and removes time data (ex: "Mon Jan 20 2025")
                 dayLabels.push(
                   format(
-                    addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), i),
+                    addDays(weekStart, i),
                     "EEE MMM-dd-yyyy"
                   )
                 );
@@ -60,7 +59,7 @@ export default function downloadMenuPDF() {
                 dayLabels.push(
                   format(
                     addDays(
-                      startOfWeek(addDays(new Date(), 7), {
+                      startOfWeek(addDays(weekStart, 7), {
                         weekStartsOn: 1,
                       }),
                       i
@@ -125,7 +124,7 @@ export default function downloadMenuPDF() {
             }
           };
     
-          formatMenuData(currentWeekDays, menuDishes, "Current Week", 40);
+          formatMenuData(currentWeekDays, menuDishes, "Selected Week", 40);
           // TODO: The upcoming week does not render correctly:
           formatMenuData(nextWeekDays, menuDishes, "Upcoming Week", 130);
           doc.save("WeeklyMenu.pdf");

--- a/src/hooks/useGenerateMenu.jsx
+++ b/src/hooks/useGenerateMenu.jsx
@@ -52,12 +52,13 @@ export default function useGenerateMenu() {
           menu: menuDishes[index] || null,
         }));
 
-        console.log(storedWeeklyMenu);
         setGeneratedWeeklyMenuAdd(combinedArray);
 
         setMenuDishes();
 
         setModalType("A");
+
+        console.log(combinedArray);
       }
     } else {
       // (Generate) if local storage does not exist
@@ -69,11 +70,12 @@ export default function useGenerateMenu() {
       }));
 
       setGeneratedWeeklyMenuAdd(combinedArray);
-      console.log(storedWeeklyMenu);
-
+    
       setMenuDishes();
 
       setModalType("A");
+
+      console.log(combinedArray);
     }
   };
 
@@ -99,12 +101,13 @@ export default function useGenerateMenu() {
         menu: menuDishes[index] || null,
       }));
 
-      console.log(storedWeeklyMenu);
       setGeneratedWeeklyMenuAdd(combinedArray);
 
       setMenuDishes();
 
       setModalType("D");
+
+      console.log(combinedArray);
     } else {
       // (Regenerate) if selected week DO NOT have a generated menu
       setModalType("E");

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,54 +1,166 @@
 import { WeeklyMenu } from "../components/weekly-menu/WeeklyMenu";
 import { NavLink, useLoaderData } from "react-router-dom";
-import { addDays, startOfWeek } from "date-fns";
-import { ToastContainer } from "react-toastify";
+import { addDays, startOfWeek, parseISO, isBefore, formatISO, addMonths } from "date-fns";
+import { ToastContainer, toast } from "react-toastify";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import AddIcon from "@mui/icons-material/Add";
 import generatePDF from "../functions/generatePDF";
+import { useEffect, useState } from "react";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+import Select from "react-select";
 
 export default function Home() {
-    //
-    const fetchDishes = useLoaderData();
-    return (
-        <div className="flex flex-col items-center w-[95%] md:w-[95%] lg:w-[80%] ">
-            {!fetchDishes.error ? (
-                <>
-                    <div className="flex flex-row justify-end md:flex-col md:items-end md:justify-center w-full lg:w-[85%]">
-                        <div
-                            onClick={generatePDF}
-                            className="md:hidden flex flex-row text-button-blue justify-center items-center w-fit border-button-blue px-1">
-                            <FileUploadIcon fontSize="medium" className="cursor-pointer" />
-                        </div>
-                        <NavLink
-                            className="flex flex-row justify-center items-center bg-button-blue border-2 text-white rounded-3xl h-[36px] w-fit px-[18px] md:px-[60px] my-2 hover:bg-white hover:text-button-blue hover:border-2 hover:border-button-blue"
-                            to={"/GenerateMenu"}>
-                            <AddIcon fontSize="small" className="" />
-                            <span className="text-sm md:text-lg">Generate Menu</span>
-                        </NavLink>
-                        <div
-                            onClick={generatePDF}
-                            className="hidden md:flex md:flex-row md:bg-gray-500 md:border-2 md:text-white md:justify-center md:items-center md:rounded-full md:h-[36px] md:w-fit md:px-[24px] md:py-[6px] md:hover:border-2 md:hover:border-solid md:hover:border-gray-500 md:hover:bg-white md:hover:text-gray-500 md:cursor-pointer">
-                            <span>Export Menu</span>
-                            <FileUploadIcon fontSize="small" className="cursor-pointer" />
-                        </div>
-                    </div>
+  const fetchDishes = useLoaderData();
 
-                    <div className="flex flex-col items-center w-full lg:w-[85%]  ">
-                        <ToastContainer />
-                        {/* Current Week menu */}
-                        <WeeklyMenu weekStartDay={startOfWeek(new Date(), { weekStartsOn: 1 })} />
+  const storedWeeklyMenu = JSON.parse(
+    localStorage.getItem("generatedWeeklyMenu")
+  );
 
-                        {/* Upcoming Week menu */}
-                        <WeeklyMenu
-                            weekStartDay={startOfWeek(addDays(new Date(), 7), {
-                                weekStartsOn: 1,
-                            })}
-                        />
-                    </div>
-                </>
-            ) : (
-                <div className="text-center italic ">{fetchDishes.error}</div>
-            )}
-        </div>
-    );
+  const [generatedWeeklyMenuReplace, setGeneratedWeeklyMenuReplace] =
+    useLocalStorage("generatedWeeklyMenu", []);
+
+  const [updatedMenu,setUpdatedMenu] = useState()
+  
+  const [storedMondays, setStoredMondays] = useState([]);
+
+  const [mondayOptions, setMondayOptions] = useState([]);
+
+  const [displayedStartOfWeek, setDisplayedStartOfWeek] = useState(startOfWeek(new Date(), { weekStartsOn: 1 })
+  );
+
+  useEffect(() => {
+    if (storedWeeklyMenu && storedWeeklyMenu.length > 0) {
+      // sorts local storage date/menu objects
+      const sortedDays = storedWeeklyMenu.sort(
+        (a, b) =>
+          Number(a.id.replace(/-/g, "")) - Number(b.id.replace(/-/g, ""))
+      );
+      console.log(sortedDays);
+
+      // deletes data that is older than 3 months from local storage
+      const sixMonthAgoMonday = startOfWeek(addMonths(new Date(), -3), { weekStartsOn: 1 });
+
+      const updatedMenu = storedWeeklyMenu.filter((item) => {
+        const itemDate = parseISO(item.id);
+        return !isBefore(itemDate, sixMonthAgoMonday);
+      });
+
+      setUpdatedMenu(updatedMenu)
+      setGeneratedWeeklyMenuReplace(updatedMenu);
+
+      // Mondays for weeks with assigned menu data
+      const mondaysData = [];
+      for (let i = 0; i < updatedMenu.length - 6; i += 7) {
+        mondaysData.push(parseISO(updatedMenu[i].id));
+      }
+      console.log(mondaysData);
+      setStoredMondays(mondaysData);
+
+      // lists out 12 past monday and 52 Mondays starting from current week for year-to-date option
+      const mondayOptionsData = [];
+      for (let i = 12*-7; i < 53*7; i += 7) {
+        mondayOptionsData.push(
+          startOfWeek(addDays(new Date(), i), { weekStartsOn: 1 })
+        );
+      }
+      console.log(mondayOptionsData);
+      const mondayOptionsObject = mondayOptionsData.map((x) => ({
+        label: `Week Starting: ${formatISO(x, { representation: "date" })}`, // format to display YYYY-MM-DD
+        data: x,
+      }));
+      console.log(mondayOptionsObject);
+      setMondayOptions(mondayOptionsObject);
+    } else {
+      console.log("No stored weekly menu data");
+    }
+  }, []);
+
+  const handleDropDown = (selected) => {
+    setDisplayedStartOfWeek(selected.data);
+  };
+
+  const isDateInUpdatedMenu = (date) => {
+    const formattedDate = formatISO(date, { representation: "date" });
+    return updatedMenu.some((item) => item.id === formattedDate);
+  }
+
+  const modifiedMondayOptions = mondayOptions.map((x) => {
+    const isInUpdatedMenu = isDateInUpdatedMenu(x.data);
+  
+    return {
+      ...x,
+      label: `${x.label} ${isInUpdatedMenu ? `\u00A0\u00A0•`: ''}`, // Append bullet point if date is in updatedMenu
+    };
+  });
+
+  return (
+    <div className="flex flex-col items-center w-[95%] md:w-[95%] lg:w-[80%] ">
+      {!fetchDishes.error ? (
+        <>
+          <div className="w-full lg:w-[85%] flex flex-col-reverse md:flex-row md:justify-between  md:items-end">
+            <div className="flex flex-row justify-center md:justify-start items-center md:items-baseline w-[100%] md:w-[300px] text-xs">
+              <Select
+              className="w-full"
+                options={modifiedMondayOptions}
+                value={{
+                  label: `Week Starting: ${formatISO(displayedStartOfWeek, {
+                    representation: "date",
+                  })}`,
+                  data: displayedStartOfWeek,
+                }}
+                onChange={handleDropDown}
+                styles={{option: (provided, state) => ({
+                  ...provided,
+                   backgroundColor:
+                   state.isFocused
+                    ? "rgba(197, 233, 255, 1)"
+                    : "rgb(221, 238, 248)",
+                    color:"black",
+                  textAlign: "left",
+                  width: "100%",
+                })}}
+              />
+            </div>
+            <div className="flex flex-row justify-end md:flex-col md:items-end md:justify-center w-full lg:w-[85%]">
+              <div
+                onClick={() => generatePDF(displayedStartOfWeek)}
+                className="md:hidden flex flex-row text-button-blue justify-center items-center w-fit border-button-blue px-1"
+              >
+                <FileUploadIcon fontSize="medium" className="cursor-pointer" />
+              </div>
+              <NavLink
+                className="flex flex-row justify-center items-center bg-button-blue border-2 text-white rounded-3xl h-[36px] w-fit px-[18px] md:px-[60px] my-2 hover:bg-white hover:text-button-blue hover:border-2 hover:border-button-blue"
+                to={"/GenerateMenu"}
+              >
+                <AddIcon fontSize="small" className="" />
+                <span className="text-sm md:text-lg">Generate Menu</span>
+              </NavLink>
+              <div
+                onClick={() => generatePDF(displayedStartOfWeek)}
+                className="hidden md:flex md:flex-row md:bg-gray-500 md:border-2 md:text-white md:justify-center md:items-center md:rounded-full md:h-[36px] md:w-fit md:px-[24px] md:py-[6px] md:hover:border-2 md:hover:border-solid md:hover:border-gray-500 md:hover:bg-white md:hover:text-gray-500 md:cursor-pointer"
+              >
+                <span>Export Menu</span>
+                <FileUploadIcon fontSize="small" className="cursor-pointer" />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center w-full lg:w-[85%]  ">
+            <ToastContainer />
+            {/* Current Week menu */}
+            <WeeklyMenu weekStartDay={displayedStartOfWeek} />
+
+            {/* Upcoming Week menu */}
+            <WeeklyMenu
+              weekStartDay={startOfWeek(addDays(displayedStartOfWeek, 7), {
+                weekStartsOn: 1,
+              })}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="text-center italic ">{fetchDishes.error}</div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
# Description
Creates a dropdown on Home page to allow users to choose which weeks to see

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
- Current week is the default week when landing on the page
- User can use the dropdown to choose from weeks options
- Automatically deletes date/menu data older than 3 months from local storage
- Allows users to choose from 3 months ago to year-to-date
- Puts a little dot next to weeks with menu assignments
- Creates pdf that exports the data of the selected week

## Related Issues


## Testing instructions
- Generate menus for past weeks and for future weeks (temporarily allowed menu generation for past week for testing)

## Screenshots (if applicable)
demo video on discord