### PR TITLE
Navbar y padding decrease per Jenny

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,7 +11,7 @@ export default function Navbar() {
     const { signedIn, handleUserAuthentication } = useAuthenticateUser();
 
     return (
-        <div className="relative py-5 w-screen md:w-[95%] lg:w-[80%] grid grid-cols-3 justify-center items-center">
+        <div className="relative py-2 w-screen md:w-[95%] lg:w-[80%] grid grid-cols-3 justify-center items-center h-fit">
             <NavLink className="w-fit col-start-2 md:col-start-1 justify-self-start" to={"/"}>
                 <img src="/logo.svg" alt="Website Logo" className="w-[200px] md:w-[160px]" />
             </NavLink>


### PR DESCRIPTION
# Description
Decreases the y padding for nav bar per Jenny's feedback to show footer without scrolling on generate menu page

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary
Decreases the y padding for nav bar per Jenny's feedback to show footer without scrolling on generate menu page

## Testing instructions
See if the footer is visible without scrolling on pages other than home

